### PR TITLE
Challenge 2: Add DeactivateOrderView

### DIFF
--- a/interview/inventory/tests.py
+++ b/interview/inventory/tests.py
@@ -1,0 +1,56 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from interview.inventory.models import Inventory, InventoryType, InventoryLanguage
+from django.utils import timezone
+import datetime
+
+class InventoryListAfterDateViewTest(APITestCase):
+    def setUp(self):
+        # Create necessary foreign key objects
+        self.inventory_type = InventoryType.objects.create(name='Type1')
+        self.inventory_language = InventoryLanguage.objects.create(name='English')
+
+        # Create inventory items with different creation dates
+        self.inventory1 = Inventory.objects.create(
+            name='Item 1',
+            type=self.inventory_type,
+            language=self.inventory_language,
+            metadata={},
+            created_at=timezone.now() - datetime.timedelta(days=5)
+        )
+        self.inventory2 = Inventory.objects.create(
+            name='Item 2',
+            type=self.inventory_type,
+            language=self.inventory_language,
+            metadata={},
+            created_at=timezone.now() - datetime.timedelta(days=3)
+        )
+        self.inventory3 = Inventory.objects.create(
+            name='Item 3',
+            type=self.inventory_type,
+            language=self.inventory_language,
+            metadata={},
+            created_at=timezone.now()
+        )
+
+    def test_missing_created_after_parameter(self):
+        url = reverse('inventory-created-after')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data['error'], 'The "created_after" query parameter is required.')
+
+    def test_invalid_created_after_format(self):
+        url = reverse('inventory-created-after')
+        response = self.client.get(url, {'created_after': 'invalid-date'})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data['error'], 'Invalid date format for "created_after". Use YYYY-MM-DD.')
+
+    def test_inventory_list_after_valid_date(self):
+        url = reverse('inventory-created-after')
+        created_after = (timezone.now() - datetime.timedelta(days=4)).date().isoformat()
+        response = self.client.get(url, {'created_after': created_after})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 2)
+        returned_ids = [item['id'] for item in response.data]
+        self.assertIn(self.inventory2.id, returned_ids)
+        self.assertIn(self.inventory3.id, returned_ids)

--- a/interview/inventory/urls.py
+++ b/interview/inventory/urls.py
@@ -1,6 +1,6 @@
 
 from django.urls import path
-from interview.inventory.views import InventoryLanguageListCreateView, InventoryLanguageRetrieveUpdateDestroyView, InventoryListCreateView, InventoryRetrieveUpdateDestroyView, InventoryTagListCreateView, InventoryTagRetrieveUpdateDestroyView, InventoryTypeListCreateView, InventoryTypeRetrieveUpdateDestroyView
+from interview.inventory.views import InventoryLanguageListCreateView, InventoryLanguageRetrieveUpdateDestroyView, InventoryListCreateView, InventoryRetrieveUpdateDestroyView, InventoryTagListCreateView, InventoryTagRetrieveUpdateDestroyView, InventoryTypeListCreateView, InventoryTypeRetrieveUpdateDestroyView, InventoryListAfterDateView
 from interview.order.views import OrderListCreateView, OrderTagListCreateView
 
 
@@ -13,4 +13,5 @@ urlpatterns = [
     path('tags/', InventoryTagListCreateView.as_view(), name='inventory-tags-list'),
     path('types/', InventoryTypeListCreateView.as_view(), name='inventory-types-list'),
     path('', InventoryListCreateView.as_view(), name='inventory-list'),
+    path('created-after/', InventoryListAfterDateView.as_view(), name='inventory-created-after'),
 ]

--- a/interview/order/serializers.py
+++ b/interview/order/serializers.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
 from interview.inventory.serializers import InventorySerializer
-
 from interview.order.models import Order, OrderTag
 
 
@@ -18,3 +17,9 @@ class OrderSerializer(serializers.ModelSerializer):
     class Meta:
         model = Order
         fields = ['id', 'inventory', 'start_date', 'embargo_date', 'tags', 'is_active']
+
+class OrderDeactivateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Order
+        fields = ['id', 'is_active']
+        read_only_fields = ['id']

--- a/interview/order/tests.py
+++ b/interview/order/tests.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework import status
+from django.urls import reverse
+
+from interview.order.models import Order, OrderTag
+from interview.inventory.models import Inventory, InventoryType, InventoryLanguage
+from django.utils import timezone
+import datetime
+
+
+class DeactivateOrderViewTest(TestCase):
+    """Tests for the DeactivateOrderView."""
+
+    def setUp(self):
+        self.client = APIClient()
+        # Create inventory dependencies
+        self.inventory_type = InventoryType.objects.create(name='Type1')
+        self.inventory_language = InventoryLanguage.objects.create(name='English')
+        self.inventory = Inventory.objects.create(
+            name='Inventory Item',
+            type=self.inventory_type,
+            language=self.inventory_language,
+            metadata={}
+        )
+        # Create an order
+        self.order = Order.objects.create(
+            inventory=self.inventory,
+            start_date=timezone.now().date(),
+            embargo_date=(timezone.now() + datetime.timedelta(days=7)).date(),
+            is_active=True
+        )
+        self.deactivate_url = reverse('order-deactivate', kwargs={'pk': self.order.pk})
+
+    def test_deactivate_order_success(self):
+        """Test deactivating an existing order."""
+        response = self.client.patch(self.deactivate_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.order.refresh_from_db()
+        self.assertFalse(self.order.is_active)
+
+    def test_deactivate_nonexistent_order(self):
+        """Test deactivating a non-existent order returns 404."""
+        url = reverse('order-deactivate', kwargs={'pk': 9999})
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/interview/order/urls.py
+++ b/interview/order/urls.py
@@ -1,10 +1,15 @@
 
 from django.urls import path
-from interview.order.views import OrderListCreateView, OrderTagListCreateView
+from interview.order.views import (
+    OrderListCreateView,
+    OrderTagListCreateView,
+    DeactivateOrderView,
+)
 
 
 urlpatterns = [
     path('tags/', OrderTagListCreateView.as_view(), name='order-detail'),
     path('', OrderListCreateView.as_view(), name='order-list'),
+    path('<int:pk>/deactivate/', DeactivateOrderView.as_view(), name='order-deactivate'),
 
 ]

--- a/interview/order/views.py
+++ b/interview/order/views.py
@@ -1,15 +1,34 @@
 from django.shortcuts import render
-from rest_framework import generics
+from rest_framework import generics, status
+from rest_framework.response import Response
 
 from interview.order.models import Order, OrderTag
-from interview.order.serializers import OrderSerializer, OrderTagSerializer
+from interview.order.serializers import (
+    OrderSerializer,
+    OrderTagSerializer,
+    OrderDeactivateSerializer,
+)
 
-# Create your views here.
 class OrderListCreateView(generics.ListCreateAPIView):
     queryset = Order.objects.all()
     serializer_class = OrderSerializer
-    
+
 
 class OrderTagListCreateView(generics.ListCreateAPIView):
     queryset = OrderTag.objects.all()
     serializer_class = OrderTagSerializer
+
+
+class DeactivateOrderView(generics.UpdateAPIView):
+    """
+    API view to deactivate an order by setting its is_active field to False.
+    """
+    queryset = Order.objects.all()
+    serializer_class = OrderDeactivateSerializer
+
+    def patch(self, request, *args, **kwargs):
+        order = self.get_object()
+        order.is_active = False
+        order.save()
+        serializer = self.get_serializer(order)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
This pull request adds a new view `DeactivateOrderView` to the `order` app, which allows deactivating an order by setting its `is_active` field to `False`. The view handles the following:
   >
   > - Accepts a `PATCH` request at the endpoint `/order/<int:pk>/deactivate/`.
   > - Returns the updated order data upon successful deactivation.
   > - Returns a `404 Not Found` error if the order does not exist.
   >
   > **Changes:**
   >
   > - Updated `serializers.py` to include `OrderDeactivateSerializer`.
   > - Updated `views.py` to include `DeactivateOrderView`.
   > - Updated `urls.py` to route to the new view.
   > - Added unit tests in `tests.py` to verify the functionality.
   >
   > **Testing:**
   >
   > - All unit tests pass.
   > - Verified the endpoint using Postman.
 